### PR TITLE
Utivder arbeidssokerregistrert med situasjon og tidspunkt

### DIFF
--- a/src/main/avro/arbeidssokerregistrert.avsc
+++ b/src/main/avro/arbeidssokerregistrert.avsc
@@ -5,5 +5,13 @@
   "fields" : [ {
       "type" : "string",
       "name" : "aktorid"
-    } ]
+    },
+    {
+       "type" : "string",
+       "name" : "brukersSituasjon"
+    },
+    {
+       "type" : "string",
+       "name" : "registreringOpprettet"
+    }]
 }


### PR DESCRIPTION
Oversikten til Oppfølging har behov for å vite brukers situasjon, type permittert, så utvider med dette.
Legger samtidig ved tidspunktet for når registreringen ble opprettet hos bruker.